### PR TITLE
Update .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -75,8 +75,3 @@ crashlytics-build.properties
 /[Aa]ssets/[Ss]treamingAssets/aa/*
 
 # End of https://www.toptal.com/developers/gitignore/api/unity
-
-# Models can get excessive in size.
-*.blend
-*.fbx
-/[Aa]ssets/[Mm]odels/


### PR DESCRIPTION
The .gitignore was updated to avoid ignoring Blender models.